### PR TITLE
fix: associated with render logics

### DIFF
--- a/src/application_windows/hit_test.rs
+++ b/src/application_windows/hit_test.rs
@@ -21,7 +21,7 @@ fn update_hit_test(
     cameras: Cameras,
 ) {
     for (window_entity, mut window, layers) in windows.iter_mut() {
-        let Some((camera, tf, _)) = cameras.find_camera(window_entity) else {
+        let Some((camera, tf, _)) = cameras.find_camera_from_window(window_entity) else {
             window.cursor_options.hit_test = false;
             continue;
         };

--- a/src/application_windows/hit_test.rs
+++ b/src/application_windows/hit_test.rs
@@ -1,8 +1,8 @@
-use crate::global_mouse::cursor::GlobalMouseCursor;
 use crate::system_param::cameras::Cameras;
 use crate::system_param::mouse_position::MousePosition;
 use bevy::app::{App, Plugin, PreUpdate};
-use bevy::prelude::{resource_exists_and_changed, Entity, IntoSystemConfigs, MeshRayCast, Query, RayCastSettings};
+use bevy::input::mouse::MouseMotion;
+use bevy::prelude::{on_event, Entity, IntoSystemConfigs, MeshRayCast, Query, RayCastSettings};
 use bevy::render::view::RenderLayers;
 use bevy::window::Window;
 
@@ -10,7 +10,7 @@ pub struct ApplicationWindowsHitTestPlugin;
 
 impl Plugin for ApplicationWindowsHitTestPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, update_hit_test.run_if(resource_exists_and_changed::<GlobalMouseCursor>));
+        app.add_systems(PreUpdate, update_hit_test.run_if(on_event::<MouseMotion>));
     }
 }
 

--- a/src/application_windows/setup.rs
+++ b/src/application_windows/setup.rs
@@ -7,17 +7,19 @@ use bevy::ecs::query::With;
 use bevy::ecs::schedule::IntoSystemConfigs;
 use bevy::log::debug;
 use bevy::math::Vec2;
-use bevy::prelude::{default, Added, Camera, Camera3d, GlobalTransform, OrthographicProjection, ParallelCommands, Projection, Res, Transform, Window};
+use bevy::prelude::{default, Camera, Camera3d, Component, GlobalTransform, NonSend, OrthographicProjection, Projection, Reflect, ReflectComponent, Res, Transform, Window};
 use bevy::prelude::{Commands, Entity, Plugin, Query};
 use bevy::render::camera::{RenderTarget, ScalingMode, Viewport};
 use bevy::render::view::RenderLayers;
 use bevy::window::{CursorOptions, Monitor, PrimaryMonitor, PrimaryWindow, WindowLevel, WindowMode, WindowRef, WindowResolution};
+use bevy::winit::WinitWindows;
 
 pub struct ApplicationWindowsSetupPlugin;
 
 impl Plugin for ApplicationWindowsSetupPlugin {
     fn build(&self, app: &mut App) {
         app
+            .register_type::<UninitializedCamera>()
             .register_type::<TargetMonitor>()
             .add_systems(Startup, (
                 despawn_default_window,
@@ -26,6 +28,10 @@ impl Plugin for ApplicationWindowsSetupPlugin {
             .add_systems(Update, initialize_camera_position);
     }
 }
+
+#[derive(Component, Debug, Reflect)]
+#[reflect(Component)]
+struct UninitializedCamera;
 
 fn despawn_default_window(
     mut commands: Commands,
@@ -57,7 +63,8 @@ fn setup_windows(
         debug!("Monitor({:?}) {:?}", monitor.physical_position, monitor.physical_size());
         window.position.set((monitor.physical_position.as_vec2() * scale_factor).as_ivec2());
         window.resolution.set_scale_factor(monitor.scale_factor as f32);
-
+        let size = window.resolution.physical_size();
+        println!("Window({:?}) {:?}", monitor.physical_position, size);
         let window_entity = commands.spawn((
             Name::new(format!("Window({:?})", monitor.physical_position)),
             TargetMonitor(monitor_entity),
@@ -81,6 +88,7 @@ fn spawn_camera(
     is_primary: bool,
 ) {
     let mut cmd = commands.spawn((
+        UninitializedCamera,
         Name::new(format!("Camera({camera_layer})")),
         RenderLayers::layer(camera_layer),
         Camera3d::default(),
@@ -106,18 +114,30 @@ fn spawn_camera(
 }
 
 fn initialize_camera_position(
-    par_commands: ParallelCommands,
-    cameras: Query<(Entity, &Camera, &GlobalTransform), Added<Camera>>,
+    mut commands: Commands,
+    cameras: Query<(Entity, &Camera, &GlobalTransform), With<UninitializedCamera>>,
+    winit_window: NonSend<WinitWindows>,
 ) {
-    cameras.par_iter().for_each(|(entity, camera, gtf)| {
+    cameras.iter().for_each(|(entity, camera, gtf)| {
+        let RenderTarget::Window(WindowRef::Entity(window_entity)) = camera.target else {
+            return;
+        };
+        let Some(window) = winit_window.get_window(window_entity) else {
+            return;
+        };
+        let pos = window.outer_position().unwrap().cast();
+        let pos = Vec2::new(pos.x, pos.y);
         let center = camera.viewport.as_ref().unwrap().physical_size.as_vec2() / 2.;
+
         let camera_pos = camera
-            .viewport_to_world_2d(gtf, center)
+            .viewport_to_world_2d(gtf, center + pos)
             .unwrap_or_default()
             .extend(4.5);
-        par_commands.command_scope(|mut commands| {
-            commands.entity(entity).insert(Transform::from_translation(camera_pos));
-        });
+        println!("Camera({:?}) {:?} {:?}", entity, camera_pos, window.outer_size());
+        commands
+            .entity(entity)
+            .insert(Transform::from_translation(camera_pos))
+            .remove::<UninitializedCamera>();
     });
 }
 

--- a/src/application_windows/setup.rs
+++ b/src/application_windows/setup.rs
@@ -47,11 +47,11 @@ fn setup_windows(
     global_cursor: Res<GlobalMouseCursor>,
     monitors: Query<(Entity, &Monitor, Option<&PrimaryMonitor>)>,
 ) {
-    let cursor_pos = global_cursor.global_cursor_pos();
+    let cursor_pos = global_cursor.global();
     let Some(scale_factor) = monitors
         .iter()
         .find_map(|(_, monitor, _)| {
-            monitor_rect(monitor).contains(cursor_pos).then_some(monitor.scale_factor as f32)
+            monitor_rect(monitor).contains(*cursor_pos).then_some(monitor.scale_factor as f32)
         })
     else {
         return;
@@ -59,12 +59,9 @@ fn setup_windows(
 
     for (layer, (monitor_entity, monitor, primary)) in monitors.iter().enumerate() {
         let mut window = create_window(monitor.physical_size().as_vec2());
-
         debug!("Monitor({:?}) {:?}", monitor.physical_position, monitor.physical_size());
         window.position.set((monitor.physical_position.as_vec2() * scale_factor).as_ivec2());
         window.resolution.set_scale_factor(monitor.scale_factor as f32);
-        let size = window.resolution.physical_size();
-        println!("Window({:?}) {:?}", monitor.physical_position, size);
         let window_entity = commands.spawn((
             Name::new(format!("Window({:?})", monitor.physical_position)),
             TargetMonitor(monitor_entity),
@@ -127,13 +124,11 @@ fn initialize_camera_position(
         };
         let pos = window.outer_position().unwrap().cast();
         let pos = Vec2::new(pos.x, pos.y);
-        let center = camera.viewport.as_ref().unwrap().physical_size.as_vec2() / 2.;
-
+        let center = camera.logical_viewport_size().unwrap() / 2.;
         let camera_pos = camera
             .viewport_to_world_2d(gtf, center + pos)
             .unwrap_or_default()
             .extend(4.5);
-        println!("Camera({:?}) {:?} {:?}", entity, camera_pos, window.outer_size());
         commands
             .entity(entity)
             .insert(Transform::from_translation(camera_pos))

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,15 @@
 pub type AppResult<T = ()> = Result<T, anyhow::Error>;
 
-#[derive(Debug, thiserror::Error)]
-pub enum AppError {
-    #[error("Failed to parse vrm extensions:\n{0}")]
-    FailedParseExtensions(#[from] serde_json::error::Error),
+pub trait OutputLog {
+    fn output_log_if_error(&self, tag: &str);
+}
+
+impl<T, E: std::error::Error> OutputLog for Result<T, E> {
+    fn output_log_if_error(&self, tag: &str) {
+        if let Err(e) = self {
+            bevy::log::error!("[{tag}]: {e}");
+        }
+    }
 }
 
 #[macro_export]

--- a/src/global_mouse/cursor.rs
+++ b/src/global_mouse/cursor.rs
@@ -1,4 +1,5 @@
 use crate::global_mouse::GlobalMouseHandle;
+use crate::system_param::GlobalScreenPos;
 use bevy::app::{App, First, PreStartup};
 use bevy::math::Vec2;
 use bevy::prelude::{Plugin, Res, ResMut, Resource};
@@ -11,8 +12,8 @@ pub struct GlobalMouseCursor {
 
 impl GlobalMouseCursor {
     #[inline(always)]
-    pub const fn global_cursor_pos(&self) -> Vec2 {
-        self.current
+    pub const fn global(&self) -> GlobalScreenPos {
+        GlobalScreenPos(self.current)
     }
 }
 

--- a/src/global_window.rs
+++ b/src/global_window.rs
@@ -9,9 +9,9 @@ pub use crate::global_window::_windows::*;
 #[cfg(target_os = "macos")]
 pub use crate::global_window::macos::*;
 
+use crate::system_param::GlobalScreenPos;
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::Resource;
-
 
 #[derive(Debug, Clone, PartialEq, Default, Resource)]
 pub struct GlobalWindow {
@@ -27,8 +27,8 @@ pub struct GlobalWindow {
 
 impl GlobalWindow {
     #[inline]
-    pub fn sitting_pos(&self, drop_pos: Vec2) -> Vec2 {
-        Vec2::new(drop_pos.x, self.frame.min.y)
+    pub fn sitting_pos(&self, drop_pos: GlobalScreenPos) -> GlobalScreenPos {
+        GlobalScreenPos(Vec2::new(drop_pos.x, self.frame.min.y))
     }
 
     /// Update the application_windows metadata.
@@ -67,12 +67,12 @@ impl GlobalWindows {
         Self(frames)
     }
 
-    pub fn find_sitting_window(&self, drop_pos: Vec2) -> Option<GlobalWindow> {
+    pub fn find_sitting_window(&self, drop_pos: GlobalScreenPos) -> Option<GlobalWindow> {
         const SITTING_THRESHOLD_HEIGHT: f32 = 80.;
         let mut areas = Vec::new();
         for sitting_area in self.0.iter() {
-            if hitting_sitting_area(&sitting_area.frame, drop_pos, SITTING_THRESHOLD_HEIGHT)
-                && !areas.iter().any(|area: &&GlobalWindow| area.frame.contains(drop_pos))
+            if hitting_sitting_area(&sitting_area.frame, *drop_pos, SITTING_THRESHOLD_HEIGHT)
+                && !areas.iter().any(|area: &&GlobalWindow| area.frame.contains(*drop_pos))
             {
                 return Some(sitting_area.clone());
             }
@@ -96,6 +96,7 @@ fn hitting_sitting_area(
 #[cfg(test)]
 mod tests {
     use crate::global_window::{hitting_sitting_area, GlobalWindow, GlobalWindows};
+    use crate::system_param::GlobalScreenPos;
     use bevy::math::{Rect, Vec2};
 
     #[test]
@@ -119,7 +120,7 @@ mod tests {
                 ..Default::default()
             },
         ]);
-        assert_eq!(areas.find_sitting_window(Vec2::new(50., 50.)), None);
+        assert_eq!(areas.find_sitting_window(GlobalScreenPos(Vec2::new(50., 50.))), None);
     }
 
     #[test]
@@ -135,7 +136,7 @@ mod tests {
             },
             bottom.clone(),
         ]);
-        assert_eq!(areas.find_sitting_window(Vec2::new(110., 50.)), Some(bottom));
+        assert_eq!(areas.find_sitting_window(GlobalScreenPos(Vec2::new(110., 50.))), Some(bottom));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             DefaultPlugins
                 .set(LogPlugin {
                     #[cfg(debug_assertions)]
-                    level: bevy::log::Level::INFO,
+                    level: bevy::log::Level::DEBUG,
                     #[cfg(target_os = "windows")]
                     filter: "wgpu_hal=off".to_string(),
                     ..default()
@@ -96,6 +96,10 @@ fn main() {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use bevy::asset::AssetPlugin;
+    use bevy::prelude::ImagePlugin;
+    use bevy::render::camera::CameraPlugin;
+    use bevy::window::WindowPlugin;
     use bevy::MinimalPlugins;
 
     pub type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
@@ -109,7 +113,13 @@ pub(crate) mod tests {
 
     pub fn test_app() -> bevy::app::App {
         let mut app = bevy::app::App::new();
-        app.add_plugins(MinimalPlugins);
+        app.add_plugins((
+            MinimalPlugins,
+            AssetPlugin::default(),
+            ImagePlugin::default(),
+            WindowPlugin::default(),
+            CameraPlugin,
+        ));
         app
     }
 }

--- a/src/mascot/drag.rs
+++ b/src/mascot/drag.rs
@@ -6,12 +6,12 @@ use crate::mascot::sitting::SittingWindow;
 use crate::mascot::{Mascot, MascotEntity};
 use crate::settings::state::{ActionGroup, ActionName, MascotAction};
 use crate::system_param::mascot_tracker::MascotTracker;
-use crate::system_param::monitors::Monitors;
+use crate::system_param::window_layers::WindowLayers;
 use bevy::app::{App, Plugin};
 use bevy::hierarchy::{HierarchyQueryExt, Parent};
 use bevy::log::debug;
 use bevy::prelude::{Commands, Drag, DragEnd, DragStart, Entity, Pointer, PointerButton, Query, Res, Trigger};
-use bevy::render::view::RenderLayers;
+use bevy::render::camera::NormalizedRenderTarget;
 
 pub struct MascotDragPlugin;
 
@@ -63,9 +63,16 @@ fn on_drag_move(
     trigger: Trigger<Pointer<Drag>>,
     mut commands: Commands,
     tracker: MascotTracker,
+    windows: WindowLayers,
 ) {
     let mascot = MascotEntity(trigger.entity());
-    let Some(transform) = tracker.tracking_on_drag(mascot, trigger.pointer_location.position) else {
+    let NormalizedRenderTarget::Window(window_ref) = trigger.pointer_location.target else {
+        return;
+    };
+    let Some(global) = windows.to_global_pos(window_ref.entity(), trigger.pointer_location.position) else {
+        return;
+    };
+    let Some(transform) = tracker.tracking_on_drag(mascot, global) else {
         return;
     };
     commands.entity(mascot.0).insert(transform);
@@ -76,28 +83,18 @@ fn on_drag_drop(
     mut commands: Commands,
     tracker: MascotTracker,
     global_cursor: Res<GlobalMouseCursor>,
-    monitors: Monitors,
-    move_targets: Query<&RenderLayers>,
     #[cfg(target_os = "windows")]
     // To run on main thread
     _: bevy::prelude::NonSend<bevy::winit::WinitWindows>,
 ) {
-    let global_cursor_pos = global_cursor.global_cursor_pos();
+    let global_cursor_pos = global_cursor.global();
     let mascot = MascotEntity(trigger.entity());
-    let Ok(layers) = move_targets.get(mascot.0) else {
-        return;
-    };
     let global_windows: GlobalWindows = obtain_global_windows().unwrap_or_default();
     match global_windows.find_sitting_window(global_cursor_pos) {
         Some(global_window) => {
-            let global_sitting_pos = global_window.sitting_pos(global_cursor_pos);
-            let sitting_window = SittingWindow::new(global_window, global_sitting_pos);
-            let Some(transform) = monitors
-                .monitor_pos(layers)
-                .and_then(|monitor_pos| {
-                    tracker.tracking_on_sitting(mascot, sitting_window.global_sitting_pos() - monitor_pos)
-                })
-            else {
+            let sitting_pos = global_window.sitting_pos(global_cursor_pos);
+            let sitting_window = SittingWindow::new(global_window, sitting_pos);
+            let Some(transform) = tracker.tracking_on_sitting(mascot, sitting_window.sitting_pos()) else {
                 return;
             };
             debug!("Sitting application_windows: {:?}", sitting_window.window.title);

--- a/src/mascot/drag.rs
+++ b/src/mascot/drag.rs
@@ -1,6 +1,5 @@
 // mod index;
 
-use crate::global_mouse::button::GlobalMouseButton;
 use crate::global_mouse::cursor::GlobalMouseCursor;
 use crate::global_window::{obtain_global_windows, GlobalWindows};
 use crate::mascot::sitting::SittingWindow;
@@ -8,12 +7,10 @@ use crate::mascot::{Mascot, MascotEntity};
 use crate::settings::state::{ActionGroup, ActionName, MascotAction};
 use crate::system_param::mascot_tracker::MascotTracker;
 use crate::system_param::monitors::Monitors;
-use crate::system_param::mouse_position::MousePosition;
-use bevy::app::{App, Plugin, Update};
+use bevy::app::{App, Plugin};
 use bevy::hierarchy::{HierarchyQueryExt, Parent};
-use bevy::input::common_conditions::{input_just_released, input_pressed};
 use bevy::log::debug;
-use bevy::prelude::{Commands, DragStart, Entity, IntoSystemConfigs, ParallelCommands, Pointer, PointerButton, Query, Res, Trigger};
+use bevy::prelude::{Commands, Drag, DragEnd, DragStart, Entity, Pointer, PointerButton, Query, Res, Trigger};
 use bevy::render::view::RenderLayers;
 
 pub struct MascotDragPlugin;
@@ -21,19 +18,15 @@ pub struct MascotDragPlugin;
 impl Plugin for MascotDragPlugin {
     fn build(&self, app: &mut App) {
         app
-            .add_systems(Update, (
-                on_drag_move.run_if(input_pressed(GlobalMouseButton::Left)),
-                on_drag_drop.run_if(input_just_released(GlobalMouseButton::Left)),
-            ));
-
-        app
             .world_mut()
             .register_component_hooks::<Mascot>()
             .on_add(|mut world, entity, _| {
                 world
                     .commands()
                     .entity(entity)
-                    .observe(on_drag_start);
+                    .observe(on_drag_start)
+                    .observe(on_drag_move)
+                    .observe(on_drag_drop);
             });
     }
 }
@@ -67,73 +60,58 @@ fn not_playing_sit_down(
 }
 
 fn on_drag_move(
-    par_commands: ParallelCommands,
+    trigger: Trigger<Pointer<Drag>>,
+    mut commands: Commands,
     tracker: MascotTracker,
-    mouse_position: MousePosition,
-    move_targets: Query<(Entity, &RenderLayers, &MascotAction)>,
 ) {
-    move_targets.par_iter().for_each(|(entity, layers, state)| {
-        if !state.group.is_drag() {
-            return;
-        }
-        let Some(cursor_pos) = mouse_position.local(layers) else {
-            return;
-        };
-        let Some(transform) = tracker.tracking_on_drag(MascotEntity(entity), cursor_pos) else {
-            return;
-        };
-        par_commands.command_scope(|mut commands| {
-            commands.entity(entity).insert(transform);
-        });
-    });
+    let mascot = MascotEntity(trigger.entity());
+    let Some(transform) = tracker.tracking_on_drag(mascot, trigger.pointer_location.position) else {
+        return;
+    };
+    commands.entity(mascot.0).insert(transform);
 }
 
 fn on_drag_drop(
-    par_commands: ParallelCommands,
+    trigger: Trigger<Pointer<DragEnd>>,
+    mut commands: Commands,
     tracker: MascotTracker,
     global_cursor: Res<GlobalMouseCursor>,
     monitors: Monitors,
-    move_targets: Query<(Entity, &RenderLayers, &MascotAction)>,
+    move_targets: Query<&RenderLayers>,
     #[cfg(target_os = "windows")]
     // To run on main thread
     _: bevy::prelude::NonSend<bevy::winit::WinitWindows>,
 ) {
     let global_cursor_pos = global_cursor.global_cursor_pos();
-    for (entity, layers, state) in move_targets.iter() {
-        if !state.group.is_drag() {
-            return;
+    let mascot = MascotEntity(trigger.entity());
+    let Ok(layers) = move_targets.get(mascot.0) else {
+        return;
+    };
+    let global_windows: GlobalWindows = obtain_global_windows().unwrap_or_default();
+    match global_windows.find_sitting_window(global_cursor_pos) {
+        Some(global_window) => {
+            let global_sitting_pos = global_window.sitting_pos(global_cursor_pos);
+            let sitting_window = SittingWindow::new(global_window, global_sitting_pos);
+            let Some(transform) = monitors
+                .monitor_pos(layers)
+                .and_then(|monitor_pos| {
+                    tracker.tracking_on_sitting(mascot, sitting_window.global_sitting_pos() - monitor_pos)
+                })
+            else {
+                return;
+            };
+            debug!("Sitting application_windows: {:?}", sitting_window.window.title);
+            commands.entity(mascot.0).insert((
+                sitting_window,
+                transform,
+                MascotAction::from_main(ActionGroup::sit_down()),
+            ));
         }
-        let mascot = MascotEntity(entity);
-        let global_windows: GlobalWindows = obtain_global_windows().unwrap_or_default();
-        match global_windows.find_sitting_window(global_cursor_pos) {
-            Some(global_window) => {
-                let global_sitting_pos = global_window.sitting_pos(global_cursor_pos);
-                let sitting_window = SittingWindow::new(global_window, global_sitting_pos);
-                let Some(transform) = monitors
-                    .monitor_pos(layers)
-                    .and_then(|monitor_pos| {
-                        tracker.tracking_on_sitting(mascot, sitting_window.global_sitting_pos() - monitor_pos)
-                    })
-                else {
-                    return;
-                };
-                debug!("Sitting application_windows: {:?}", sitting_window.window.title);
-                par_commands.command_scope(|mut commands| {
-                    commands.entity(entity).insert((
-                        sitting_window,
-                        transform,
-                        MascotAction::from_main(ActionGroup::sit_down()),
-                    ));
-                });
-            }
-            None => {
-                par_commands.command_scope(|mut commands| {
-                    commands.entity(entity).insert(MascotAction {
-                        group: ActionGroup::drag(),
-                        name: ActionName::drop(),
-                    });
-                });
-            }
+        None => {
+            commands.entity(mascot.0).insert(MascotAction {
+                group: ActionGroup::drag(),
+                name: ActionName::drop(),
+            });
         }
     }
 }

--- a/src/mascot/render_layers.rs
+++ b/src/mascot/render_layers.rs
@@ -4,7 +4,7 @@ use bevy::app::{App, PreUpdate};
 use bevy::core::Name;
 use bevy::hierarchy::Children;
 use bevy::log::debug;
-use bevy::prelude::{Changed, Commands, Entity, ParallelCommands, Plugin, Query, Transform, With, Without};
+use bevy::prelude::{Added, Changed, Commands, Entity, Or, ParallelCommands, Plugin, Query, Transform, With, Without};
 use bevy::render::view::RenderLayers;
 
 pub struct MascotRenderLayersPlugin;
@@ -18,7 +18,7 @@ impl Plugin for MascotRenderLayersPlugin {
 
 fn change_render_layers(
     par_commands: ParallelCommands,
-    mascots: Query<(Entity, &Name, &Transform, &RenderLayers, Option<&Children>), (Changed<Transform>, With<Mascot>)>,
+    mascots: Query<(Entity, &Name, &Transform, &RenderLayers, &Children), (With<Mascot>, Or<(Changed<Transform>, Added<Children>)>)>,
     coordinate: Coordinate,
     meshes: Query<(Option<&RenderLayers>, Option<&Children>), Without<Mascot>>,
 ) {
@@ -33,10 +33,8 @@ fn change_render_layers(
         new_tf.translation = new_pos;
         debug!("{name:?}'s render layer changed to {new_layers:?}");
         par_commands.command_scope(|mut commands| {
-            if let Some(children) = children {
-                for child in children.iter() {
-                    update_layers(*child, new_layers.clone(), &mut commands, &meshes);
-                }
+            for child in children.iter() {
+                update_layers(*child, new_layers.clone(), &mut commands, &meshes);
             }
             commands.entity(entity).insert((
                 new_layers.clone(),

--- a/src/mascot/render_layers.rs
+++ b/src/mascot/render_layers.rs
@@ -1,7 +1,7 @@
 use crate::mascot::Mascot;
-use bevy::app::{App, PreUpdate, Update};
+use bevy::app::{App, Update};
 use bevy::hierarchy::Children;
-use bevy::prelude::{Added, Changed, Commands, Entity, Or, ParallelCommands, Plugin, Query, With, Without};
+use bevy::prelude::{Added, Changed, Commands, Entity, IntoSystemConfigs, Or, Plugin, Query, With, Without};
 use bevy::render::view::RenderLayers;
 
 pub struct MascotRenderLayersPlugin;
@@ -9,44 +9,10 @@ pub struct MascotRenderLayersPlugin;
 impl Plugin for MascotRenderLayersPlugin {
     fn build(&self, app: &mut App) {
         app
-            .add_systems(PreUpdate, change_render_layers)
-            .add_systems(Update, update_children_layers);
+            .add_systems(Update, (
+                update_children_layers,
+            ).chain());
     }
-}
-
-fn change_render_layers(
-    _par_commands: ParallelCommands,
-    // mascots: Query<(Entity, &Name, &Transform, &RenderLayers), (Changed<Transform>, With<Mascot>)>,
-    // cameras: Cameras,
-    // mascot_aabb: MascotAabb,
-) {
-    // mascots.par_iter().for_each(|(entity, name, tf, current_layers)| {
-    //     let Some((_, current_gtf, _)) = cameras.find_camera_from_layers(current_layers) else {
-    //         return;
-    //     };
-    //     // let (min, max) = mascot_aabb.calculate(entity);
-    //     // let Some((min_camera, min_gtf, min_layers)) = cameras.find_camera_from_world_pos(min) else {
-    //     //     return;
-    //     // };
-    //     // let Some((_, max_gtf, max_layers)) = cameras.find_camera_from_world_pos(max) else {
-    //     //     return;
-    //     // };
-    //     // if current_layers == min_layers {
-    //     //     return;
-    //     // }
-    //     // let mut new_tf = *tf;
-    //     // new_tf.translation = min_camera.viewport_to_world_2d(min_gtf, Vec2::ZERO).unwrap().extend(0.);
-    //     // new_tf.translation += (min_gtf.translation().xy() - current_gtf.translation().xy())
-    //     //     .normalize()
-    //     //     .extend(0.);
-    //     // debug!("{name:?}'s render layer changed to {min_layers:?}");
-    //     // par_commands.command_scope(|commands| {
-    //     //     commands.entity(entity).insert((
-    //     //         min_layers.clone(),
-    //     //         new_tf,
-    //     //     ));
-    //     // });
-    // });
 }
 
 fn update_children_layers(

--- a/src/mascot/render_layers.rs
+++ b/src/mascot/render_layers.rs
@@ -1,50 +1,67 @@
 use crate::mascot::Mascot;
-use crate::system_param::coordinate::Coordinate;
-use bevy::app::{App, PreUpdate};
-use bevy::core::Name;
+use bevy::app::{App, PreUpdate, Update};
 use bevy::hierarchy::Children;
-use bevy::log::debug;
-use bevy::prelude::{Added, Changed, Commands, Entity, Or, ParallelCommands, Plugin, Query, Transform, With, Without};
+use bevy::prelude::{Added, Changed, Commands, Entity, Or, ParallelCommands, Plugin, Query, With, Without};
 use bevy::render::view::RenderLayers;
 
 pub struct MascotRenderLayersPlugin;
 
 impl Plugin for MascotRenderLayersPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, change_render_layers);
+        app
+            .add_systems(PreUpdate, change_render_layers)
+            .add_systems(Update, update_children_layers);
     }
 }
 
-
 fn change_render_layers(
-    par_commands: ParallelCommands,
-    mascots: Query<(Entity, &Name, &Transform, &RenderLayers, &Children), (With<Mascot>, Or<(Changed<Transform>, Added<Children>)>)>,
-    coordinate: Coordinate,
-    meshes: Query<(Option<&RenderLayers>, Option<&Children>), Without<Mascot>>,
+    _par_commands: ParallelCommands,
+    // mascots: Query<(Entity, &Name, &Transform, &RenderLayers), (Changed<Transform>, With<Mascot>)>,
+    // cameras: Cameras,
+    // mascot_aabb: MascotAabb,
 ) {
-    mascots.par_iter().for_each(|(entity, name, tf, layers, children)| {
-        let Some((new_pos, new_layers)) = coordinate.new_render_layers_if_overall_monitor(
-            layers,
-            tf.translation,
-        ) else {
-            return;
-        };
-        let mut new_tf = *tf;
-        new_tf.translation = new_pos;
-        debug!("{name:?}'s render layer changed to {new_layers:?}");
-        par_commands.command_scope(|mut commands| {
-            for child in children.iter() {
-                update_layers(*child, new_layers.clone(), &mut commands, &meshes);
-            }
-            commands.entity(entity).insert((
-                new_layers.clone(),
-                new_tf,
-            ));
-        });
-    });
+    // mascots.par_iter().for_each(|(entity, name, tf, current_layers)| {
+    //     let Some((_, current_gtf, _)) = cameras.find_camera_from_layers(current_layers) else {
+    //         return;
+    //     };
+    //     // let (min, max) = mascot_aabb.calculate(entity);
+    //     // let Some((min_camera, min_gtf, min_layers)) = cameras.find_camera_from_world_pos(min) else {
+    //     //     return;
+    //     // };
+    //     // let Some((_, max_gtf, max_layers)) = cameras.find_camera_from_world_pos(max) else {
+    //     //     return;
+    //     // };
+    //     // if current_layers == min_layers {
+    //     //     return;
+    //     // }
+    //     // let mut new_tf = *tf;
+    //     // new_tf.translation = min_camera.viewport_to_world_2d(min_gtf, Vec2::ZERO).unwrap().extend(0.);
+    //     // new_tf.translation += (min_gtf.translation().xy() - current_gtf.translation().xy())
+    //     //     .normalize()
+    //     //     .extend(0.);
+    //     // debug!("{name:?}'s render layer changed to {min_layers:?}");
+    //     // par_commands.command_scope(|commands| {
+    //     //     commands.entity(entity).insert((
+    //     //         min_layers.clone(),
+    //     //         new_tf,
+    //     //     ));
+    //     // });
+    // });
 }
 
-fn update_layers(
+fn update_children_layers(
+    mut commands: Commands,
+    mascots: Query<(&RenderLayers, &Children), (With<Mascot>, Or<(Changed<RenderLayers>, Added<Children>)>)>,
+    meshes: Query<(Option<&RenderLayers>, Option<&Children>), Without<Mascot>>,
+) {
+    for (layers, children) in mascots.iter() {
+        for child in children.iter() {
+            replace_children_layers(*child, layers.clone(), &mut commands, &meshes);
+        }
+    }
+}
+
+fn replace_children_layers(
     root_entity: Entity,
     render_layers: RenderLayers,
     commands: &mut Commands,
@@ -53,7 +70,7 @@ fn update_layers(
     if let Ok((layers, children)) = meshes.get(root_entity) {
         if let Some(children) = children {
             for child in children.iter() {
-                update_layers(*child, render_layers.clone(), commands, meshes);
+                replace_children_layers(*child, render_layers.clone(), commands, meshes);
             }
         }
         if layers.is_some() {

--- a/src/mascot/sitting.rs
+++ b/src/mascot/sitting.rs
@@ -3,13 +3,12 @@ use crate::global_window::GlobalWindow;
 use crate::mascot::MascotEntity;
 use crate::settings::state::{ActionName, MascotAction};
 use crate::system_param::mascot_tracker::MascotTracker;
-use crate::system_param::monitors::Monitors;
 use crate::system_param::mouse_position::MousePosition;
+use crate::system_param::GlobalScreenPos;
 use bevy::app::{App, PostUpdate, Update};
 use bevy::input::common_conditions::{input_just_pressed, input_just_released};
 use bevy::math::Vec2;
 use bevy::prelude::{debug, on_event, Changed, Commands, Component, Entity, Event, EventReader, EventWriter, IntoSystemConfigs, Local, ParallelCommands, Plugin, Query, Transform, With};
-use bevy::render::view::RenderLayers;
 use bevy::utils::HashMap;
 use bevy::window::RequestRedraw;
 use itertools::Itertools;
@@ -51,10 +50,10 @@ pub struct SittingWindow {
 impl SittingWindow {
     pub fn new(
         global_window: GlobalWindow,
-        sitting_pos: Vec2,
+        sitting_pos: GlobalScreenPos,
     ) -> Self {
         Self {
-            mascot_viewport_offset: sitting_pos - global_window.frame.min,
+            mascot_viewport_offset: *sitting_pos - global_window.frame.min,
             window: global_window,
             dragging: false,
         }
@@ -70,8 +69,8 @@ impl SittingWindow {
     }
 
     #[inline]
-    pub fn global_sitting_pos(&self) -> Vec2 {
-        self.window.frame.min + self.mascot_viewport_offset
+    pub fn sitting_pos(&self) -> GlobalScreenPos {
+        GlobalScreenPos(self.window.frame.min + self.mascot_viewport_offset)
     }
 }
 
@@ -106,20 +105,16 @@ fn move_sitting_pos(
     mut redraw: EventWriter<RequestRedraw>,
     mut er: EventReader<MoveSittingPos>,
     tracker: MascotTracker,
-    mascots: Query<(&SittingWindow, &RenderLayers)>,
-    monitors: Monitors,
+    mascots: Query<&SittingWindow>,
 ) {
     for mascot in er
         .read()
         .map(|e| e.mascot)
         .unique()
     {
-        if let Ok((sitting_window, layers)) = mascots.get(mascot.0) {
-            let Some(monitor_pos) = monitors.monitor_pos(layers) else {
-                return;
-            };
-            let sitting_pos = sitting_window.global_sitting_pos() - monitor_pos;
-            if let Some(transform) = tracker.tracking_on_sitting(mascot, sitting_pos) {
+        if let Ok(sitting_window) = mascots.get(mascot.0) {
+            let global = sitting_window.sitting_pos();
+            if let Some(transform) = tracker.tracking_on_sitting(mascot, global) {
                 commands.entity(mascot.0).insert(transform);
             }
         }
@@ -136,7 +131,7 @@ fn start_tracking(
         .iter_mut()
         .filter(|s| !s.dragging)
     {
-        if sitting_window.window.frame.contains(mouse_position.global()) {
+        if sitting_window.window.frame.contains(*mouse_position.global()) {
             debug!("Start tracking sitting application_windows: {:?}", sitting_window.window.title);
             sitting_window.dragging = true;
             redraw.send(RequestRedraw);
@@ -147,21 +142,17 @@ fn start_tracking(
 fn track_to_sitting_window(
     mut redraw: EventWriter<RequestRedraw>,
     par_commands: ParallelCommands,
-    sitting_windows: Query<(Entity, &SittingWindow, &RenderLayers)>,
+    sitting_windows: Query<(Entity, &SittingWindow)>,
     tracker: MascotTracker,
-    monitors: Monitors,
 ) {
-    sitting_windows.par_iter().for_each(|(mascot_entity, sitting_window, layers)| {
+    sitting_windows.par_iter().for_each(|(mascot_entity, sitting_window)| {
         if !sitting_window.dragging {
             return;
         }
-        let Some(monitor_pos) = monitors.monitor_pos(layers) else {
-            return;
-        };
         let Some(new_sitting_window) = sitting_window.update() else {
             return;
         };
-        let sitting_pos = new_sitting_window.global_sitting_pos() - monitor_pos;
+        let sitting_pos = new_sitting_window.sitting_pos();
         let Some(transform) = tracker.tracking_on_sitting(MascotEntity(mascot_entity), sitting_pos) else {
             return;
         };

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -81,11 +81,11 @@ fn open_menu(
     if !(matches!(trigger.event.button, PointerButton::Secondary) && menus.is_empty()) {
         return;
     }
-    let global_cursor_pos = mouse.global_cursor_pos();
-    let Some((_, monitor, _)) = monitors.find_monitor_from_screen_pos(global_cursor_pos) else {
+    let global_cursor_pos = mouse.global();
+    let Some((_, monitor, _)) = monitors.find_monitor_from_global_screen_pos(global_cursor_pos) else {
         return;
     };
-    let (position, resolution) = fit_position(global_cursor_pos, &monitor_rect(monitor));
+    let (position, resolution) = fit_position(*global_cursor_pos, &monitor_rect(monitor));
     let mascot_entity = parents.root_ancestor(trigger.target);
     commands.spawn((
         Menu,
@@ -146,7 +146,7 @@ fn mark_initialized_menu(
             let monitor_pos = monitors.monitor_pos(layers).unwrap_or_default();
             let scale_factor = monitors.scale_factor(layers).unwrap_or(1.0);
             let (_, max) = mascot_aabb.calculate(*mascot_entity);
-            let max = cameras.to_viewport_pos(layers, max).unwrap_or(mouse.global_cursor_pos());
+            let max = cameras.to_viewport_pos(layers, max).unwrap_or(*mouse.global());
             let max = monitor_pos + max;
             let pos = max * scale_factor;
             winit_window.set_outer_position(PhysicalPosition::new(pos.x, pos.y));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,7 @@ pub mod state;
 
 use crate::settings::load::AppSettingsLoadPlugin;
 use crate::settings::preferences::action::{ActionPreferences, ActionProperties};
-use crate::settings::preferences::{MascotPreferences, MascotPreferencesResource};
+use crate::settings::preferences::{MascotLocation, MascotLocationPreferences};
 use crate::settings::save::AppSettingsSavePlugin;
 use crate::settings::state::MascotAction;
 use crate::vrma::Vrma;
@@ -20,7 +20,7 @@ impl Plugin for AppSettingsPlugin {
         app
             .register_type::<MascotAction>()
             .register_type::<ActionProperties>()
-            .register_type::<MascotPreferencesResource>()
+            .register_type::<MascotLocationPreferences>()
             .add_plugins((
                 AppSettingsLoadPlugin,
                 AppSettingsSavePlugin,
@@ -50,9 +50,16 @@ fn remove_action(
     actions.cleanup(&exists_actions);
 }
 
-fn save_file_path() -> PathBuf {
+fn app_data_dir() -> PathBuf {
     dirs::data_dir()
         .unwrap_or_default()
-        .join("bevy_baby")
-        .join("mascots.json")
+        .join(env!("CARGO_PKG_NAME"))
+}
+
+fn mascot_locations_json_path() -> PathBuf {
+    app_data_dir().join("mascot_locations.json")
+}
+
+fn actions_json_path() -> PathBuf {
+    app_data_dir().join("actions.json")
 }

--- a/src/settings/load.rs
+++ b/src/settings/load.rs
@@ -1,33 +1,46 @@
 use crate::error::AppResult;
-use crate::settings::preferences::{AppPreferences, MascotPreferencesResource};
-use crate::settings::save_file_path;
+use crate::settings::preferences::action::ActionPreferences;
+use crate::settings::preferences::MascotLocationPreferences;
+use crate::settings::{actions_json_path, mascot_locations_json_path};
 use bevy::app::{App, Startup};
-use bevy::log::error;
 use bevy::prelude::{Commands, Plugin};
 
 pub struct AppSettingsLoadPlugin;
 
 impl Plugin for AppSettingsLoadPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, load_settings);
+        app.add_systems(Startup, (
+            load_mascot_locations,
+            load_actions,
+        ));
     }
 }
 
-fn load_settings(
+fn load_mascot_locations(
     mut commands: Commands,
 ) {
-    let preferences = read_settings().unwrap_or_else(|e| {
-        error!("Failed to load settings: {:?}", e);
-        AppPreferences::default()
-    });
-    commands.insert_resource(MascotPreferencesResource(preferences.mascots));
-    commands.insert_resource(preferences.actions);
+    commands.insert_resource(read_mascot_locations().unwrap_or_default());
 }
 
-fn read_settings() -> AppResult<AppPreferences> {
-    let path = save_file_path();
+fn load_actions(
+    mut commands: Commands,
+) {
+    commands.insert_resource(read_actions().unwrap_or_default());
+}
+
+fn read_mascot_locations() -> AppResult<MascotLocationPreferences> {
+    let path = mascot_locations_json_path();
     if !path.exists() {
-        return Ok(AppPreferences::default());
+        return Ok(MascotLocationPreferences::default());
+    }
+    let json = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+fn read_actions() -> AppResult<ActionPreferences> {
+    let path = actions_json_path();
+    if !path.exists() {
+        return Ok(ActionPreferences::default());
     }
     let json = std::fs::read_to_string(path)?;
     Ok(serde_json::from_str(&json)?)

--- a/src/settings/preferences.rs
+++ b/src/settings/preferences.rs
@@ -1,33 +1,46 @@
 pub mod action;
 
-use crate::settings::preferences::action::ActionPreferences;
+use crate::system_param::coordinate::Coordinate;
+use bevy::math::{Quat, Vec3};
 use bevy::prelude::{Reflect, Resource, Transform};
+use bevy::render::view::RenderLayers;
+use bevy::utils::{default, HashMap};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
-pub struct AppPreferences {
-    pub mascots: Vec<MascotPreferences>,
-    pub actions: ActionPreferences,
-}
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default, Resource, Clone, Reflect)]
-pub struct MascotPreferencesResource(pub Vec<MascotPreferences>);
+pub struct MascotLocationPreferences(pub HashMap<PathBuf, MascotLocation>);
 
-impl MascotPreferencesResource {
-    pub fn transform(&self, path: &Path) -> Transform {
-        self.0
-            .iter()
-            .find_map(|p| {
-                (p.path == path).then_some(p.transform)
-            })
-            .unwrap_or_default()
+impl MascotLocationPreferences {
+    pub fn load(&self, path: &Path, coordinate: &Coordinate) -> (Transform, RenderLayers) {
+        match self.load_transform(path, coordinate) {
+            Some(transform_and_layers) => transform_and_layers,
+            None => {
+                let (world_pos, layers) = coordinate.default_mascot_pos_and_layers();
+                (Transform {
+                    translation: world_pos,
+                    ..default()
+                }, layers)
+            }
+        }
+    }
+
+    fn load_transform(&self, path: &Path, coordinate: &Coordinate) -> Option<(Transform, RenderLayers)> {
+        let location = self.0.get(path)?;
+        let (world_pos, layers) = coordinate.initial_mascot_pos_and_layers(location.ndc, &location.monitor_name)?;
+        Some((Transform {
+            translation: world_pos,
+            scale: location.scale,
+            rotation: location.rotation,
+        }, layers))
     }
 }
 
 #[derive(PartialEq, Debug, Default, Serialize, Deserialize, Clone, Reflect)]
-pub struct MascotPreferences {
-    pub transform: Transform,
-    pub path: PathBuf,
+pub struct MascotLocation {
+    pub monitor_name: Option<String>,
+    pub ndc: Vec3,
+    pub scale: Vec3,
+    pub rotation: Quat,
 }
 

--- a/src/settings/preferences.rs
+++ b/src/settings/preferences.rs
@@ -3,7 +3,6 @@ pub mod action;
 use crate::system_param::coordinate::Coordinate;
 use bevy::math::{Quat, Vec3};
 use bevy::prelude::{Reflect, Resource, Transform};
-use bevy::render::view::RenderLayers;
 use bevy::utils::{default, HashMap};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -12,34 +11,34 @@ use std::path::{Path, PathBuf};
 pub struct MascotLocationPreferences(pub HashMap<PathBuf, MascotLocation>);
 
 impl MascotLocationPreferences {
-    pub fn load(&self, path: &Path, coordinate: &Coordinate) -> (Transform, RenderLayers) {
-        match self.load_transform(path, coordinate) {
-            Some(transform_and_layers) => transform_and_layers,
+    pub fn load_transform(&self, path: &Path, coordinate: &Coordinate) -> Transform {
+        match self.try_load_transform(path, coordinate) {
+            Some(transform) => transform,
             None => {
-                let (world_pos, layers) = coordinate.default_mascot_pos_and_layers();
-                (Transform {
+                let world_pos = coordinate.default_mascot_pos_and_layers();
+                Transform {
                     translation: world_pos,
                     ..default()
-                }, layers)
+                }
             }
         }
     }
 
-    fn load_transform(&self, path: &Path, coordinate: &Coordinate) -> Option<(Transform, RenderLayers)> {
+    fn try_load_transform(&self, path: &Path, coordinate: &Coordinate) -> Option<Transform> {
         let location = self.0.get(path)?;
-        let (world_pos, layers) = coordinate.initial_mascot_pos_and_layers(location.ndc, &location.monitor_name)?;
-        Some((Transform {
+        let world_pos = coordinate.mascot_position(location.viewport_pos, &location.monitor_name)?;
+        Some(Transform {
             translation: world_pos,
             scale: location.scale,
             rotation: location.rotation,
-        }, layers))
+        })
     }
 }
 
 #[derive(PartialEq, Debug, Default, Serialize, Deserialize, Clone, Reflect)]
 pub struct MascotLocation {
     pub monitor_name: Option<String>,
-    pub ndc: Vec3,
+    pub viewport_pos: Vec3,
     pub scale: Vec3,
     pub rotation: Quat,
 }

--- a/src/settings/preferences/action.rs
+++ b/src/settings/preferences/action.rs
@@ -1,5 +1,5 @@
 use crate::settings::state::{ActionGroup, ActionName, MascotAction};
-use bevy::prelude::{Component, Reflect, Resource};
+use bevy::prelude::{Component, Deref, Reflect, Resource};
 use bevy::utils::hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
@@ -63,7 +63,7 @@ macro_rules! actions {
 }
 
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Resource)]
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Resource, Deref)]
 pub struct ActionPreferences(HashMap<ActionGroup, HashMap<ActionName, ActionProperties>>);
 
 impl ActionPreferences {

--- a/src/settings/state.rs
+++ b/src/settings/state.rs
@@ -58,11 +58,6 @@ impl ActionGroup {
     }
 
     #[inline]
-    pub fn is_drag(&self) -> bool {
-        self.0 == Self::DRAG
-    }
-
-    #[inline]
     pub fn is_sit_down(&self) -> bool {
         self.0 == Self::SIT_DOWN
     }

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -1,3 +1,6 @@
+use bevy::math::Vec2;
+use bevy::prelude::Deref;
+
 pub mod monitors;
 pub mod mesh_aabb;
 pub mod cameras;
@@ -7,3 +10,9 @@ pub mod child_searcher;
 pub mod vrm_animation_players;
 pub mod bone_offsets;
 pub mod coordinate;
+pub mod window_layers;
+
+/// Represents the global screen coordinates.
+/// If there are multiple screens, the coordinates of the leftmost screen are used as the origin.
+#[derive(Debug, Copy, Clone, PartialEq, Deref)]
+pub struct GlobalScreenPos(pub Vec2);

--- a/src/system_param/cameras.rs
+++ b/src/system_param/cameras.rs
@@ -14,8 +14,14 @@ pub struct Cameras<'w, 's> {
 }
 
 impl Cameras<'_, '_> {
+    pub fn all_layers(&self) -> RenderLayers {
+        self.cameras.iter().fold(RenderLayers::none(), |l1, (_, _, l2)| {
+            l1 | l2.clone()
+        })
+    }
+
     #[inline]
-    pub fn find_camera(&self, window_entity: Entity) -> Option<CameraQuery> {
+    pub fn find_camera_from_window(&self, window_entity: Entity) -> Option<CameraQuery> {
         self
             .cameras
             .iter()
@@ -25,30 +31,30 @@ impl Cameras<'_, '_> {
     }
 
     #[inline]
+    pub fn find_camera_from_world_pos(&self, world_pos: Vec3) -> Option<CameraQuery> {
+        self
+            .cameras
+            .iter()
+            .find(|(camera, gtf, _)| {
+                camera
+                    .logical_viewport_rect()
+                    .is_some_and(|viewport| {
+                        let Ok(pos) = camera.world_to_viewport(gtf, world_pos) else {
+                            return false;
+                        };
+                        viewport.contains(pos)
+                    })
+            })
+    }
+
+    #[inline]
     pub fn find_camera_from_layers(&self, layers: &RenderLayers) -> Option<CameraQuery> {
         self
             .cameras
             .iter()
             .find(|(_, _, layer)| {
-                layer == &layers
+                layers.intersects(layer)
             })
-    }
-
-    // pub fn find_camera_from_world_pos(&self, world_pos: Vec3) -> Option<CameraQuery> {
-    //     self
-    //         .cameras
-    //         .iter()
-    //         .find_map(|(camera, gtf, layers)| {
-    //             let viewport = camera.viewport.as_ref().unwrap();
-    //             let min = camera.viewport_to_world_2d(gtf, Vec2::ZERO).ok()?;
-    //             let max = camera.viewport_to_world_2d(gtf, viewport.physical_size.as_vec2()).ok()?;
-    //             Rect::from_corners(min, max).contains(world_pos.truncate()).then_some((camera, gtf, layers))
-    //         })
-    // }
-
-    pub fn to_ndc(&self, layers: &RenderLayers, world_pos: Vec3) -> Option<Vec3> {
-        let (camera, camera_tf, _) = self.find_camera_from_layers(layers)?;
-        camera.world_to_ndc(camera_tf, world_pos)
     }
 
     #[inline]
@@ -58,15 +64,42 @@ impl Cameras<'_, '_> {
     }
 
     #[inline]
-    pub fn to_world_pos(&self, layers: &RenderLayers, ndc: Vec3) -> Option<Vec3> {
-        let (camera, camera_tf, _) = self.find_camera_from_layers(layers)?;
-        camera.ndc_to_world(camera_tf, ndc)
-    }
-
-    #[inline]
-    pub fn to_world_pos_from_viewport(&self, layers: &RenderLayers, viewport_pos: Vec2) -> Option<Vec3> {
-        let (camera, camera_tf, _) = self.find_camera_from_layers(layers)?;
+    pub fn to_world_pos_from_viewport(&self, window_entity: Entity, viewport_pos: Vec2) -> Option<Vec3> {
+        let (camera, camera_tf, _) = self.find_camera_from_window(window_entity)?;
         let pos = camera.viewport_to_world_2d(camera_tf, viewport_pos).unwrap();
         Some(pos.extend(0.))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::system_param::cameras::Cameras;
+    use crate::tests::{test_app, TestResult};
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::{Camera, Commands, GlobalTransform};
+    use bevy::render::view::RenderLayers;
+
+    #[test]
+    fn test_all_layers() -> TestResult {
+        let mut app = test_app();
+        app.world_mut().run_system_once(|mut commands: Commands| {
+            commands.spawn((
+                Camera::default(),
+                GlobalTransform::default(),
+                RenderLayers::layer(1)
+            ));
+            commands.spawn((
+                Camera::default(),
+                GlobalTransform::default(),
+                RenderLayers::layer(2)
+            ));
+        })?;
+        app.update();
+
+        let layers = app.world_mut().run_system_once(|cameras: Cameras| {
+            cameras.all_layers()
+        })?;
+        assert_eq!(layers, RenderLayers::from_layers(&[1, 2]));
+        Ok(())
     }
 }

--- a/src/system_param/cameras.rs
+++ b/src/system_param/cameras.rs
@@ -60,7 +60,7 @@ impl Cameras<'_, '_> {
     #[inline]
     pub fn to_world_pos(&self, layers: &RenderLayers, viewport_pos: Vec2) -> Option<Vec3> {
         let (camera, camera_tf, _) = self.find_camera_from_layers(layers)?;
-        let ray = camera.viewport_to_world(camera_tf, viewport_pos).unwrap();
-        Some(ray.get_point(camera_tf.translation().distance(Vec3::ZERO)))
+        let pos = camera.viewport_to_world_2d(camera_tf, viewport_pos).unwrap();
+        Some(pos.extend(0.))
     }
 }

--- a/src/system_param/coordinate.rs
+++ b/src/system_param/coordinate.rs
@@ -3,8 +3,7 @@ use crate::system_param::cameras::Cameras;
 use crate::system_param::monitors::Monitors;
 use bevy::ecs::system::SystemParam;
 use bevy::math::Vec3;
-use bevy::prelude::{Entity, Query, With};
-use bevy::render::view::RenderLayers;
+use bevy::prelude::{Entity, Query, Vec3Swizzles, With};
 
 #[derive(SystemParam)]
 pub struct Coordinate<'w, 's> {
@@ -14,40 +13,27 @@ pub struct Coordinate<'w, 's> {
 }
 
 impl Coordinate<'_, '_> {
-    //TODO: new_render_layers_if_overall_monitor
-    #[inline]
-    #[allow(unused)]
-    pub fn new_render_layers_if_overall_monitor(
-        &self,
-        current_render_layers: &RenderLayers,
-        world_pos: Vec3,
-    ) -> Option<(Vec3, &RenderLayers)> {
-        let viewport_pos = self.cameras.to_viewport_pos(current_render_layers, world_pos)?;
-        let (new_viewport, new_layers) = self.monitors.new_render_layers_if_overall_monitor(current_render_layers, viewport_pos)?;
-        Some((self.cameras.to_world_pos_from_viewport(new_layers, new_viewport)?, new_layers))
-    }
-
-    pub fn default_mascot_pos_and_layers(&self) -> (Vec3, RenderLayers) {
+    pub fn default_mascot_pos_and_layers(&self) -> Vec3 {
         let entity = self.primary_camera.single();
-        let (pos, layers) = self.cameras
+        self.cameras
             .cameras
             .get(entity)
             .ok()
-            .and_then(|(camera, gtf, layers)| {
+            .and_then(|(camera, gtf, _)| {
                 let pos = camera.ndc_to_world(gtf, Vec3::default().with_y(0.))?;
-                Some((pos, layers.clone()))
+                Some(pos.with_z(0.))
             })
-            .unwrap_or_default();
-        (pos.with_z(0.), layers)
+            .unwrap_or_default()
     }
 
-    pub fn initial_mascot_pos_and_layers(
+    pub fn mascot_position(
         &self,
-        ndc: Vec3,
+        viewport_pos: Vec3,
         monitor_name: &Option<String>,
-    ) -> Option<(Vec3, RenderLayers)> {
+    ) -> Option<Vec3> {
         let (_, _, layers) = self.monitors.find_monitor_from_name(monitor_name.as_ref()?)?;
-        let world_pos = self.cameras.to_world_pos(layers, ndc)?;
-        Some((world_pos, layers.clone()))
+        let (camera, gtf, _) = self.cameras.find_camera_from_layers(layers)?;
+        let world_pos = camera.viewport_to_world_2d(gtf, viewport_pos.xy()).ok()?;
+        Some(world_pos.extend(viewport_pos.z))
     }
 }

--- a/src/system_param/coordinate.rs
+++ b/src/system_param/coordinate.rs
@@ -14,7 +14,9 @@ pub struct Coordinate<'w, 's> {
 }
 
 impl Coordinate<'_, '_> {
+    //TODO: new_render_layers_if_overall_monitor
     #[inline]
+    #[allow(unused)]
     pub fn new_render_layers_if_overall_monitor(
         &self,
         current_render_layers: &RenderLayers,
@@ -22,23 +24,30 @@ impl Coordinate<'_, '_> {
     ) -> Option<(Vec3, &RenderLayers)> {
         let viewport_pos = self.cameras.to_viewport_pos(current_render_layers, world_pos)?;
         let (new_viewport, new_layers) = self.monitors.new_render_layers_if_overall_monitor(current_render_layers, viewport_pos)?;
-        Some((self.cameras.to_world_pos(new_layers, new_viewport)?, new_layers))
+        Some((self.cameras.to_world_pos_from_viewport(new_layers, new_viewport)?, new_layers))
     }
 
-    /// If the passed position is outside the screen, return the default position and layers of the mascot.
-    pub fn initial_mascot_pos_and_layers(&self, load_pos: Vec3) -> (Vec3, RenderLayers) {
-        match self.cameras.find_camera_from_world_pos(load_pos) {
-            Some((_, _, layers)) => (load_pos, layers.clone()),
-            None => {
-                let entity = self.primary_camera.single();
-                let (pos, layers) = self.cameras.cameras.get(entity)
-                    .ok()
-                    .and_then(|(camera, gtf, layers)| {
-                        let pos = camera.viewport_to_world_2d(gtf, camera.viewport.as_ref().unwrap().physical_size.as_vec2() / 2.).ok()?;
-                        Some((pos, layers.clone()))
-                    }).unwrap_or_default();
-                (pos.extend(0.), layers)
-            }
-        }
+    pub fn default_mascot_pos_and_layers(&self) -> (Vec3, RenderLayers) {
+        let entity = self.primary_camera.single();
+        let (pos, layers) = self.cameras
+            .cameras
+            .get(entity)
+            .ok()
+            .and_then(|(camera, gtf, layers)| {
+                let pos = camera.ndc_to_world(gtf, Vec3::default().with_y(0.))?;
+                Some((pos, layers.clone()))
+            })
+            .unwrap_or_default();
+        (pos.with_z(0.), layers)
+    }
+
+    pub fn initial_mascot_pos_and_layers(
+        &self,
+        ndc: Vec3,
+        monitor_name: &Option<String>,
+    ) -> Option<(Vec3, RenderLayers)> {
+        let (_, _, layers) = self.monitors.find_monitor_from_name(monitor_name.as_ref()?)?;
+        let world_pos = self.cameras.to_world_pos(layers, ndc)?;
+        Some((world_pos, layers.clone()))
     }
 }

--- a/src/system_param/mascot_tracker.rs
+++ b/src/system_param/mascot_tracker.rs
@@ -44,7 +44,7 @@ impl MascotTracker<'_, '_> {
     ) -> Option<Transform> {
         let (tf, render_layers) = self.mascots.get(mascot.0).ok()?;
         let hips_offset = self.offsets.hips_offset(mascot)?;
-        let mut cursor_pos = self.camera.to_world_pos(render_layers, view_port_pos)?;
+        let mut cursor_pos = self.camera.to_world_pos_from_viewport(render_layers, view_port_pos)?;
 
         let mut new_tf = *tf;
         cursor_pos.y -= hips_offset.y * adjust;

--- a/src/system_param/mascot_tracker.rs
+++ b/src/system_param/mascot_tracker.rs
@@ -1,19 +1,17 @@
 use crate::mascot::{Mascot, MascotEntity};
 use crate::system_param::bone_offsets::BoneOffsets;
 use crate::system_param::cameras::Cameras;
+use crate::system_param::window_layers::{window_local_pos, WindowLayers};
+use crate::system_param::GlobalScreenPos;
 use bevy::ecs::system::SystemParam;
-use bevy::math::Vec2;
 use bevy::prelude::{Camera, Query, Transform, With, Without};
-use bevy::render::view::RenderLayers;
 
 #[derive(SystemParam)]
 pub struct MascotTracker<'w, 's> {
-    mascots: Query<'w, 's, (
-        &'static mut Transform,
-        &'static RenderLayers,
-    ), (With<Mascot>, Without<Camera>)>,
+    mascots: Query<'w, 's, &'static mut Transform, (With<Mascot>, Without<Camera>)>,
     camera: Cameras<'w, 's>,
     offsets: BoneOffsets<'w, 's>,
+    windows: WindowLayers<'w, 's>,
 }
 
 impl MascotTracker<'_, '_> {
@@ -21,31 +19,32 @@ impl MascotTracker<'_, '_> {
     pub fn tracking_on_sitting(
         &self,
         mascot: MascotEntity,
-        view_port_pos: Vec2,
+        pos: GlobalScreenPos,
     ) -> Option<Transform> {
         // TODO: Adjust the position by multiplying by 0.9. It may be misaligned depending on the animation or model.
-        self.tracking(mascot, view_port_pos, 0.9)
+        self.tracking(mascot, pos, 0.9)
     }
 
     #[inline]
     pub fn tracking_on_drag(
         &self,
         mascot: MascotEntity,
-        view_port_pos: Vec2,
+        pos: GlobalScreenPos,
     ) -> Option<Transform> {
-        self.tracking(mascot, view_port_pos, 1.0)
+        self.tracking(mascot, pos, 1.0)
     }
 
     fn tracking(
         &self,
         mascot: MascotEntity,
-        view_port_pos: Vec2,
+        pos: GlobalScreenPos,
         adjust: f32,
     ) -> Option<Transform> {
-        let (tf, render_layers) = self.mascots.get(mascot.0).ok()?;
+        let tf = self.mascots.get(mascot.0).ok()?;
         let hips_offset = self.offsets.hips_offset(mascot)?;
-        let mut cursor_pos = self.camera.to_world_pos_from_viewport(render_layers, view_port_pos)?;
-
+        let (window_entity, window, _) = self.windows.find_window_from_global_screen_pos(pos)?;
+        let viewport_pos = window_local_pos(window, pos);
+        let mut cursor_pos = self.camera.to_world_pos_from_viewport(window_entity, viewport_pos)?;
         let mut new_tf = *tf;
         cursor_pos.y -= hips_offset.y * adjust;
         new_tf.translation = cursor_pos;

--- a/src/system_param/monitors.rs
+++ b/src/system_param/monitors.rs
@@ -32,6 +32,12 @@ impl Monitors<'_, '_> {
             })
     }
 
+    pub fn find_monitor_from_name(&self, monitor_name: &str) -> Option<(Entity, &Monitor, &RenderLayers)> {
+        self.monitors.iter().find(|(_, monitor, _)| {
+            monitor.name.as_ref().is_some_and(|name| name == monitor_name)
+        })
+    }
+
     pub fn find_monitor_from_screen_pos(&self, viewport_pos: Vec2) -> Option<(Entity, &Monitor, &RenderLayers)> {
         self.monitors.iter().find(|(_, monitor, _)| {
             monitor_rect(monitor).contains(viewport_pos)

--- a/src/system_param/monitors.rs
+++ b/src/system_param/monitors.rs
@@ -1,4 +1,5 @@
 use crate::mascot::Mascot;
+use crate::system_param::GlobalScreenPos;
 use bevy::ecs::system::SystemParam;
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::{Entity, Query, Without};
@@ -11,36 +12,15 @@ pub struct Monitors<'w, 's> {
 }
 
 impl Monitors<'_, '_> {
-    #[inline]
-    pub fn new_render_layers_if_overall_monitor(
-        &self,
-        current_render_layers: &RenderLayers,
-        viewport_pos: Vec2,
-    ) -> Option<(Vec2, &RenderLayers)> {
-        let (current_monitor_entity, monitor) = self.find_monitor(current_render_layers)?;
-        let monitor_pos = monitor.physical_position.as_vec2();
-        self
-            .monitors
-            .iter()
-            .filter(|(entity, _, _)| entity != &current_monitor_entity)
-            .find_map(|(_, monitor, layers)| {
-                if monitor_rect(monitor).contains(viewport_pos + monitor_pos) {
-                    Some((viewport_pos + monitor_pos, layers))
-                } else {
-                    None
-                }
-            })
-    }
-
     pub fn find_monitor_from_name(&self, monitor_name: &str) -> Option<(Entity, &Monitor, &RenderLayers)> {
         self.monitors.iter().find(|(_, monitor, _)| {
             monitor.name.as_ref().is_some_and(|name| name == monitor_name)
         })
     }
 
-    pub fn find_monitor_from_screen_pos(&self, viewport_pos: Vec2) -> Option<(Entity, &Monitor, &RenderLayers)> {
+    pub fn find_monitor_from_global_screen_pos(&self, global: GlobalScreenPos) -> Option<(Entity, &Monitor, &RenderLayers)> {
         self.monitors.iter().find(|(_, monitor, _)| {
-            monitor_rect(monitor).contains(viewport_pos)
+            monitor_rect(monitor).contains(*global)
         })
     }
 
@@ -63,8 +43,8 @@ impl Monitors<'_, '_> {
         self
             .monitors
             .iter()
-            .find_map(|(entity, monitor, monitor_layers)| {
-                (monitor_layers == render_layers).then_some((entity, monitor))
+            .find_map(|(entity, monitor, layer)| {
+                render_layers.intersects(layer).then_some((entity, monitor))
             })
     }
 }

--- a/src/system_param/mouse_position.rs
+++ b/src/system_param/mouse_position.rs
@@ -1,5 +1,6 @@
 use crate::global_mouse::cursor::GlobalMouseCursor;
 use crate::system_param::monitors::Monitors;
+use crate::system_param::GlobalScreenPos;
 use bevy::ecs::system::SystemParam;
 use bevy::math::Vec2;
 use bevy::prelude::Res;
@@ -13,14 +14,14 @@ pub struct MousePosition<'w, 's> {
 
 impl MousePosition<'_, '_> {
     #[inline]
-    pub fn global(&self) -> Vec2 {
-        self.cursor.global_cursor_pos()
+    pub fn global(&self) -> GlobalScreenPos {
+        self.cursor.global()
     }
 
     #[inline]
     pub fn local(&self, render_layers: &RenderLayers) -> Option<Vec2> {
-        let global_pos = self.cursor.global_cursor_pos();
+        let global_pos = self.cursor.global();
         let monitor_pos = self.monitors.monitor_pos(render_layers)?;
-        Some(global_pos - monitor_pos)
+        Some(*global_pos - monitor_pos)
     }
 }

--- a/src/system_param/window_layers.rs
+++ b/src/system_param/window_layers.rs
@@ -1,0 +1,45 @@
+use crate::system_param::GlobalScreenPos;
+use bevy::ecs::system::SystemParam;
+use bevy::math::{Rect, Vec2};
+use bevy::prelude::{Entity, Query, With};
+use bevy::render::view::RenderLayers;
+use bevy::window::{Window, WindowPosition};
+
+#[derive(SystemParam)]
+pub struct WindowLayers<'w, 's> {
+    pub windows: Query<'w, 's, (Entity, &'static Window, &'static RenderLayers), With<Window>>,
+}
+
+impl WindowLayers<'_, '_> {
+    pub fn find_window_from_global_screen_pos(&self, pos: GlobalScreenPos) -> Option<(Entity, &Window, &RenderLayers)> {
+        self.windows.iter().find(|(_, window, _)| {
+            window_to_rect(window).contains(*pos)
+        })
+    }
+
+    pub fn to_global_pos(&self, window: Entity, local_pos: Vec2) -> Option<GlobalScreenPos> {
+        let (_, window, _) = self.windows.get(window).ok()?;
+        let WindowPosition::At(position) = window.position else {
+            panic!("Unreachable code");
+        };
+        Some(GlobalScreenPos(position.as_vec2() + local_pos))
+    }
+}
+
+
+#[inline]
+pub fn window_local_pos(window: &Window, global_screen_pos: GlobalScreenPos) -> Vec2 {
+    let WindowPosition::At(position) = window.position else {
+        panic!("Unreachable code");
+    };
+    *global_screen_pos - position.as_vec2()
+}
+
+#[inline]
+fn window_to_rect(window: &Window) -> Rect {
+    let WindowPosition::At(position) = window.position else {
+        panic!("Unreachable code");
+    };
+    let position = position.as_vec2();
+    Rect::from_corners(position, position + window.resolution.size())
+}

--- a/src/vrm/load.rs
+++ b/src/vrm/load.rs
@@ -96,10 +96,8 @@ fn load_models(
         .flat_map(|handle| handle.path())
         .filter(|path| !exists_mascots.contains(&path.path()))
     {
-        let (tf, layers) = locations.load(asset_path.path(), &coordinate);
         commands.spawn((
-            tf,
-            layers,
+            locations.load_transform(asset_path.path(), &coordinate),
             VrmPath(asset_path.path().to_path_buf()),
             VrmHandle(asset_server.load(asset_path)),
         ));
@@ -141,7 +139,7 @@ fn receive_events(
         if let AssetSourceEvent::AddedAsset(path) = event {
             let relative_path = PathBuf::from("models").join(&path);
             commands.spawn((
-                mascot_preferences.load(&relative_path, &coordinate),
+                mascot_preferences.load_transform(&relative_path, &coordinate),
                 VrmHandle(asset_server.load(models_dir().join(path))),
                 VrmPath(relative_path),
             ));

--- a/src/vrm/spawn.rs
+++ b/src/vrm/spawn.rs
@@ -1,4 +1,5 @@
 use crate::mascot::Mascot;
+use crate::system_param::cameras::Cameras;
 use crate::system_param::child_searcher::ChildSearcher;
 use crate::vrm::extensions::{MorphTargetBind, VrmExtensions, VrmNode};
 use crate::vrm::loader::{Vrm, VrmHandle};
@@ -11,7 +12,6 @@ use bevy::gltf::GltfNode;
 use bevy::log::{error, info};
 use bevy::math::Quat;
 use bevy::prelude::{Added, Children, Commands, Component, Deref, DespawnRecursiveExt, Entity, EventWriter, Plugin, Query, Reflect, Res, Transform};
-use bevy::render::view::RenderLayers;
 use bevy::scene::SceneRoot;
 use bevy::utils::HashMap;
 
@@ -103,11 +103,12 @@ impl HumanoidBoneNodes {
 fn spawn_vrm(
     mut commands: Commands,
     mut ew: EventWriter<RequestLoadVrma>,
+    cameras: Cameras,
     node_assets: Res<Assets<GltfNode>>,
     vrm_assets: Res<Assets<Vrm>>,
-    handles: Query<(Entity, &VrmHandle, &Transform, &VrmPath, &RenderLayers)>,
+    handles: Query<(Entity, &VrmHandle, &Transform, &VrmPath)>,
 ) {
-    for (vrm_handle_entity, handle, tf, vrm_path, layers) in handles.iter() {
+    for (vrm_handle_entity, handle, tf, vrm_path) in handles.iter() {
         let Some(vrm) = vrm_assets.get(handle.0.id()) else {
             continue;
         };
@@ -133,7 +134,7 @@ fn spawn_vrm(
             SceneRoot(scene.clone()),
             vrm_path.clone(),
             *tf,
-            layers.clone(),
+            cameras.all_layers(),
             VrmExpressions::new(&extensions, &node_assets, &vrm.gltf.nodes),
             HumanoidBoneNodes::new(
                 &extensions.vrmc_vrm.humanoid.human_bones,


### PR DESCRIPTION
## Mascot render layers

Fixed the issue where the render layer of the mascot was changed when moving between monitors, now all layers are set at spawn time

## Save mascot locations

Changed to load the mascot's position from the monitor name and viewport coordinates where the mascot is currently displayed.