### PR TITLE
update: rename to registry

### DIFF
--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -1,10 +1,14 @@
 pub mod loader;
-pub mod spawn;
+mod spawn;
 pub mod extensions;
 mod load;
 mod spring_bone;
+pub mod humanoid_bone;
+pub mod expressions;
 
 use crate::new_type;
+use crate::vrm::expressions::VrmExpressionPlugin;
+use crate::vrm::humanoid_bone::VrmHumanoidBonePlugin;
 use crate::vrm::load::VrmLoadPlugin;
 use crate::vrm::loader::{Vrm, VrmLoaderPlugin};
 use crate::vrm::spawn::VrmSpawnPlugin;
@@ -45,6 +49,8 @@ impl Plugin for VrmPlugin {
                 VrmLoaderPlugin,
                 VrmSpawnPlugin,
                 VrmSpringBonePlugin,
+                VrmHumanoidBonePlugin,
+                VrmExpressionPlugin,
             ));
     }
 }

--- a/src/vrm/expressions.rs
+++ b/src/vrm/expressions.rs
@@ -1,6 +1,7 @@
 use crate::vrm::extensions::vrmc_vrm::MorphTargetBind;
 use crate::vrm::extensions::VrmExtensions;
 use crate::vrm::VrmExpression;
+use bevy::app::Plugin;
 use bevy::asset::{Assets, Handle};
 use bevy::core::Name;
 use bevy::gltf::GltfNode;
@@ -14,9 +15,9 @@ pub struct ExpressionNode {
 }
 
 #[derive(Component, Deref, Reflect)]
-pub struct VrmExpressions(HashMap<VrmExpression, Vec<ExpressionNode>>);
+pub struct VrmExpressionRegistry(HashMap<VrmExpression, Vec<ExpressionNode>>);
 
-impl VrmExpressions {
+impl VrmExpressionRegistry {
     pub fn new(
         extensions: &VrmExtensions,
         node_assets: &Assets<GltfNode>,
@@ -41,6 +42,14 @@ impl VrmExpressions {
             })
             .collect()
         )
+    }
+}
+
+pub struct VrmExpressionPlugin;
+
+impl Plugin for VrmExpressionPlugin {
+    fn build(&self, app: &mut bevy::app::App) {
+        app.register_type::<VrmExpressionRegistry>();
     }
 }
 

--- a/src/vrm/humanoid_bone.rs
+++ b/src/vrm/humanoid_bone.rs
@@ -1,28 +1,20 @@
 use crate::system_param::child_searcher::ChildSearcher;
 use crate::vrm::extensions::VrmNode;
 use crate::vrm::{BonePgRestQuaternion, BoneRestTransform, VrmBone, VrmHipsBoneTo};
+use bevy::app::{App, Plugin, Update};
 use bevy::asset::{Assets, Handle};
 use bevy::core::Name;
 use bevy::gltf::GltfNode;
 use bevy::hierarchy::Children;
 use bevy::math::Quat;
-use bevy::prelude::{Added, App, Commands, Component, Deref, Entity, Plugin, Query, Reflect, Transform, Update};
+use bevy::prelude::{Added, Commands, Component, Deref, Entity, Query, Reflect, Transform};
 use bevy::utils::HashMap;
 
-pub struct VrmAttachBonesPlugin;
-
-impl Plugin for VrmAttachBonesPlugin {
-    fn build(&self, app: &mut App) {
-        app
-            .register_type::<HumanoidBoneNodes>()
-            .add_systems(Update, attach_bones);
-    }
-}
 
 #[derive(Component, Deref, Reflect)]
-pub struct HumanoidBoneNodes(HashMap<VrmBone, Name>);
+pub struct HumanoidBoneRegistry(HashMap<VrmBone, Name>);
 
-impl HumanoidBoneNodes {
+impl HumanoidBoneRegistry {
     pub fn new(
         bones: &HashMap<String, VrmNode>,
         node_assets: &Assets<GltfNode>,
@@ -40,10 +32,20 @@ impl HumanoidBoneNodes {
     }
 }
 
+pub struct VrmHumanoidBonePlugin;
+
+impl Plugin for VrmHumanoidBonePlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .register_type::<HumanoidBoneRegistry>()
+            .add_systems(Update, attach_bones);
+    }
+}
+
 fn attach_bones(
     mut commands: Commands,
     searcher: ChildSearcher,
-    mascots: Query<(Entity, &HumanoidBoneNodes), Added<Children>>,
+    mascots: Query<(Entity, &HumanoidBoneRegistry), Added<Children>>,
     transforms: Query<(&Transform, Option<&Children>)>,
 ) {
     for (mascot_entity, humanoid_bones) in mascots.iter() {

--- a/src/vrm/spawn.rs
+++ b/src/vrm/spawn.rs
@@ -1,9 +1,9 @@
 use crate::mascot::Mascot;
 use crate::system_param::cameras::Cameras;
+use crate::vrm::expressions::VrmExpressionRegistry;
 use crate::vrm::extensions::VrmExtensions;
+use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrm::loader::{Vrm, VrmHandle};
-use crate::vrm::spawn::bone::VrmAttachBonesPlugin;
-use crate::vrm::spawn::expressions::VrmExpressions;
 use crate::vrm::spring_bone::registry::*;
 use crate::vrm::VrmPath;
 use crate::vrma::load::RequestLoadVrma;
@@ -14,23 +14,12 @@ use bevy::gltf::GltfNode;
 use bevy::log::{error, info};
 use bevy::prelude::{Commands, DespawnRecursiveExt, Entity, EventWriter, Plugin, Query, Res, Transform};
 use bevy::scene::SceneRoot;
-use bone::HumanoidBoneNodes;
-
-pub mod bone;
-pub mod expressions;
 
 pub struct VrmSpawnPlugin;
 
 impl Plugin for VrmSpawnPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .register_type::<VrmExpressions>()
-            .add_plugins((
-                VrmAttachBonesPlugin,
-            ))
-            .add_systems(Update, (
-                spawn_vrm,
-            ));
+        app.add_systems(Update, spawn_vrm);
     }
 }
 
@@ -69,8 +58,8 @@ fn spawn_vrm(
             vrm_path.clone(),
             *tf,
             cameras.all_layers(),
-            VrmExpressions::new(&extensions, &node_assets, &vrm.gltf.nodes),
-            HumanoidBoneNodes::new(
+            VrmExpressionRegistry::new(&extensions, &node_assets, &vrm.gltf.nodes),
+            HumanoidBoneRegistry::new(
                 &extensions.vrmc_vrm.humanoid.human_bones,
                 &node_assets,
                 &vrm.gltf.nodes,

--- a/src/vrma/load.rs
+++ b/src/vrma/load.rs
@@ -2,7 +2,7 @@ use crate::mascot::Mascot;
 use crate::power_state::Loading;
 use crate::settings::preferences::action::ActionPreferences;
 use crate::settings::state::MascotAction;
-use crate::vrm::spawn::bone::HumanoidBoneNodes;
+use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrm::VrmExpression;
 use crate::vrma::animation::{AnimationPlayerEntities, VrmAnimationGraph};
 use crate::vrma::extensions::VrmaExtensions;
@@ -211,7 +211,7 @@ fn spawn_vrma(
             obtain_vrma_duration(&clip_assets, &vrma.gltf.animations),
             VrmAnimationGraph::new(vrma.gltf.animations.to_vec(), &mut animation_graphs),
             VrmaExpressionNames::new(&extensions),
-            HumanoidBoneNodes::new(
+            HumanoidBoneRegistry::new(
                 &extensions.vrmc_vrm_animation.humanoid.human_bones,
                 &node_assets,
                 &vrma.gltf.nodes,

--- a/src/vrma/retarget/bone.rs
+++ b/src/vrma/retarget/bone.rs
@@ -1,5 +1,5 @@
 use crate::system_param::child_searcher::ChildSearcher;
-use crate::vrm::spawn::bone::HumanoidBoneNodes;
+use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrm::{BonePgRestQuaternion, BoneRestTransform};
 use crate::vrma::retarget::CurrentRetargeting;
 use crate::vrma::{RetargetSource, RetargetTo};
@@ -32,7 +32,7 @@ struct PreviousPosition(Vec3);
 
 fn retarget_bones_to_mascot(
     par_commands: ParallelCommands,
-    bones: Query<(Entity, &RetargetTo, &HumanoidBoneNodes), Added<Children>>,
+    bones: Query<(Entity, &RetargetTo, &HumanoidBoneRegistry), Added<Children>>,
     transforms: Query<&Transform>,
     names: Query<&Name>,
     searcher: ChildSearcher,

--- a/src/vrma/retarget/expressions.rs
+++ b/src/vrma/retarget/expressions.rs
@@ -1,6 +1,6 @@
 use crate::system_param::child_searcher::ChildSearcher;
 
-use crate::vrm::spawn::expressions::VrmExpressions;
+use crate::vrm::expressions::VrmExpressionRegistry;
 use crate::vrma::load::VrmaExpressionNames;
 use crate::vrma::retarget::CurrentRetargeting;
 use crate::vrma::{RetargetSource, RetargetTo};
@@ -35,7 +35,7 @@ struct RetargetExpressionTo(Vec<BindExpressionNode>);
 fn retarget_expressions_to_mascot(
     mut commands: Commands,
     vrma: Query<(Entity, &RetargetTo, &VrmaExpressionNames), Added<Children>>,
-    mascots: Query<&VrmExpressions>,
+    mascots: Query<&VrmExpressionRegistry>,
     searcher: ChildSearcher,
 ) {
     for (vrma_entity, retarget, expressions) in vrma.iter() {


### PR DESCRIPTION
Changed the naming convention to unify the structure that associates bones, facial expressions, etc., information with entities as `*Registry`.