### PR TITLE
fix: retarget bones

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             DefaultPlugins
                 .set(LogPlugin {
                     #[cfg(debug_assertions)]
-                    level: bevy::log::Level::DEBUG,
+                    level: bevy::log::Level::INFO,
                     #[cfg(target_os = "windows")]
                     filter: "wgpu_hal=off".to_string(),
                     ..default()

--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -15,8 +15,7 @@ use crate::vrm::spawn::VrmSpawnPlugin;
 use crate::vrm::spring_bone::VrmSpringBonePlugin;
 use bevy::app::{App, Plugin};
 use bevy::asset::AssetApp;
-use bevy::math::Quat;
-use bevy::prelude::{Component, Entity, Reflect, Transform};
+use bevy::prelude::{Component, Entity, GlobalTransform, Reflect, Transform};
 use std::path::PathBuf;
 
 new_type!(VrmBone, String);
@@ -29,7 +28,7 @@ pub struct VrmPath(pub PathBuf);
 pub struct BoneRestTransform(pub Transform);
 
 #[derive(Debug, Reflect, Copy, Clone, Component)]
-pub struct BonePgRestQuaternion(pub Quat);
+pub struct BoneRestGlobalTransform(pub GlobalTransform);
 
 #[derive(Debug, Reflect, Copy, Clone, Component)]
 pub struct VrmHipsBoneTo(pub Entity);
@@ -42,6 +41,7 @@ impl Plugin for VrmPlugin {
             .init_asset::<Vrm>()
             .register_type::<VrmPath>()
             .register_type::<BoneRestTransform>()
+            .register_type::<BoneRestGlobalTransform>()
             .register_type::<VrmHipsBoneTo>()
             .register_type::<VrmBone>()
             .add_plugins((

--- a/src/vrm/humanoid_bone.rs
+++ b/src/vrm/humanoid_bone.rs
@@ -1,15 +1,18 @@
 use crate::system_param::child_searcher::ChildSearcher;
 use crate::vrm::extensions::VrmNode;
-use crate::vrm::{BonePgRestQuaternion, BoneRestTransform, VrmBone, VrmHipsBoneTo};
+use crate::vrm::{BoneRestGlobalTransform, BoneRestTransform, VrmBone, VrmHipsBoneTo};
 use bevy::app::{App, Plugin, Update};
 use bevy::asset::{Assets, Handle};
 use bevy::core::Name;
 use bevy::gltf::GltfNode;
 use bevy::hierarchy::Children;
-use bevy::math::Quat;
-use bevy::prelude::{Added, Commands, Component, Deref, Entity, Query, Reflect, Transform};
+use bevy::prelude::*;
 use bevy::utils::HashMap;
+use serde::{Deserialize, Serialize};
 
+#[derive(Component, Reflect, Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[reflect(Component, Serialize, Deserialize)]
+pub struct Hips;
 
 #[derive(Component, Deref, Reflect)]
 pub struct HumanoidBoneRegistry(HashMap<VrmBone, Name>);
@@ -38,6 +41,7 @@ impl Plugin for VrmHumanoidBonePlugin {
     fn build(&self, app: &mut App) {
         app
             .register_type::<HumanoidBoneRegistry>()
+            .register_type::<Hips>()
             .add_systems(Update, attach_bones);
     }
 }
@@ -46,45 +50,26 @@ fn attach_bones(
     mut commands: Commands,
     searcher: ChildSearcher,
     mascots: Query<(Entity, &HumanoidBoneRegistry), Added<Children>>,
-    transforms: Query<(&Transform, Option<&Children>)>,
+    transforms: Query<(&Transform, &GlobalTransform)>,
 ) {
     for (mascot_entity, humanoid_bones) in mascots.iter() {
         for (bone, name) in humanoid_bones.iter() {
             let Some(bone_entity) = searcher.find_from_name(mascot_entity, name.as_str()) else {
                 continue;
             };
-            commands.entity(bone_entity).insert(bone.clone());
-            // Use hips when sitting on window.
+            let Ok((tf, gtf)) = transforms.get(bone_entity) else {
+                continue;
+            };
+            commands.entity(bone_entity).insert((
+                bone.clone(),
+                BoneRestTransform(*tf),
+                BoneRestGlobalTransform(*gtf),
+            ));
+            // Use hips when sitting on window and retargeting.
             if bone.0 == "hips" {
                 commands.entity(mascot_entity).insert(VrmHipsBoneTo(bone_entity));
-                recursive_attach_pg_resets(
-                    &mut commands,
-                    bone_entity,
-                    Quat::IDENTITY,
-                    &transforms,
-                );
+                commands.entity(bone_entity).insert(Hips);
             }
-        }
-    }
-}
-
-fn recursive_attach_pg_resets(
-    commands: &mut Commands,
-    bone_entity: Entity,
-    rest: Quat,
-    transforms: &Query<(&Transform, Option<&Children>)>,
-) {
-    let Ok((tf, children)) = transforms.get(bone_entity) else {
-        return;
-    };
-    let pg_rest = BonePgRestQuaternion(tf.rotation * rest);
-    commands.entity(bone_entity).insert((
-        BoneRestTransform(*tf),
-        pg_rest,
-    ));
-    if let Some(children) = children {
-        for child in children.iter() {
-            recursive_attach_pg_resets(commands, *child, pg_rest.0, transforms);
         }
     }
 }


### PR DESCRIPTION
After researching VRM1.0, it seems that starting from 1.0, local axes are now preserved. As a result, retargeting rotation can be simply achieved by transferring the local rotation directly.

Regarding position retargeting, I have decided to apply it only to the Hips bone based on the following specification:
>Animations for nodes specified as Humanoid bones are treated as animation data for the Humanoid bone. The animation data for the Humanoid bone must not include scales for the Humanoid bone. Also, the animation for the Humanoid bone must not include translations for bones other than the Hips bone.

This change allows support for VRM and VRMA files exported from software other than Blender. However, it also means that VRMA files exported from Blender will no longer function correctly.
The reason for this is that VRM and VRMA files exported from Blender are likely to be broken, and I have found relevant issues indicating this problem.

Currently, I’m unsure what to do because, as far as I know, Blender is the only tool that can export animations with facial expressions.

https://github.com/user-attachments/assets/5338d0e4-b8a7-4efd-8c93-1598c48ab6a8

