### PR TITLE
update: use file logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements
 
 - Split settings file into two files: `actions.json` and `mascot_locations.json`.
+- Log file is now saved in the Logs directory.
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
  "rand 0.9.0",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "tracing-appender",
  "windows 0.60.0",
  "winit",
 ]
@@ -7023,6 +7023,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bevy_webview_wry = { version = "0.3", features = ["api"] }
 serde = { version = "1", features = ["derive"] }
 device_query = "3"
 dirs = "6"
-thiserror = "2"
 serde_json = "1"
 winit = "0.30"
 rand = "0.9"
@@ -29,6 +28,7 @@ crossbeam = "0.8.4"
 itertools = "0.14"
 anyhow = "1.0.96"
 bevy-inspector-egui = { version = "0.29", optional = true }
+tracing-appender = "0.2.3"
 
 [target.'cfg(target_os="macos")'.dependencies]
 core-graphics = { version = "0.24.0" }
@@ -51,3 +51,25 @@ windows = { version = "0.60", features = [
 [features]
 default = []
 develop = ["dep:bevy-inspector-egui"]
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.dev]
+opt-level = 1
+
+# This is used by trunk as it doesn't support custom profiles: https://github.com/trunk-rs/trunk/issues/605
+# xbuild also uses this profile for building android AABs because I couldn't find a configuration for it
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+strip = true
+
+# Profile for distribution
+[profile.dist]
+inherits = "release"
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ use crate::settings::preferences::action::{ActionPreferences, ActionProperties};
 use crate::settings::preferences::{MascotLocation, MascotLocationPreferences};
 use crate::settings::save::AppSettingsSavePlugin;
 use crate::settings::state::MascotAction;
+use crate::util::app_data_dir;
 use crate::vrma::Vrma;
 use bevy::app::{App, Update};
 use bevy::prelude::{any_component_removed, Added, IntoSystemConfigs, Plugin, Query, ResMut, With};
@@ -48,12 +49,6 @@ fn remove_action(
 ) {
     let exists_actions = vrma.iter().cloned().collect::<Vec<_>>();
     actions.cleanup(&exists_actions);
-}
-
-fn app_data_dir() -> PathBuf {
-    dirs::data_dir()
-        .unwrap_or_default()
-        .join(env!("CARGO_PKG_NAME"))
 }
 
 fn mascot_locations_json_path() -> PathBuf {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,22 @@
 use std::path::{Path, PathBuf};
 
 pub fn models_dir() -> PathBuf {
+    assets_dir().join("models")
+}
+
+pub fn assets_dir() -> PathBuf {
     std::env::current_exe()
         .ok()
         .and_then(|exe_path| Some(exe_path.parent()?.to_path_buf()))
         .or_else(|| std::env::current_dir().ok())
         .unwrap_or_default()
         .join("assets")
-        .join("models")
+}
+
+pub fn app_data_dir() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_default()
+        .join(env!("CARGO_PKG_NAME"))
 }
 
 pub fn remove_mystery_file_if_exists(dir: &Path) {


### PR DESCRIPTION
The log filter has been set to Error.

Additionally,
the application now output log files.
The output destination is `{dirs::data_dir}/{APP_NAME}/Logs`, and `dirs::data_dir` varies by OS. MacOS: $HOME/Library/Application Support/
Windows: {FOLDERID_RoamingAppData}

Currently, APP_NAME is `bevy_baby`, but if the application name changes, this path will change as well.