### PR TITLE
fix: setup window position

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,10 @@ use bevy::app::{App, PluginGroup};
 use bevy::color::Color;
 use bevy::log::tracing_subscriber::Layer;
 use bevy::log::{BoxedLayer, LogPlugin};
-use bevy::prelude::{default, AmbientLight, ClearColor, MeshPickingPlugin};
+use bevy::prelude::{default, AmbientLight, ClearColor, MeshPickingPlugin, Window};
 use bevy::render::settings::{RenderCreation, WgpuSettings};
 use bevy::render::RenderPlugin;
-use bevy::window::{ExitCondition, WindowPlugin};
+use bevy::window::{ExitCondition, WindowPlugin, WindowResolution};
 use bevy::DefaultPlugins;
 use bevy_webview_wry::api::{AllLogPlugins, AppExitApiPlugin};
 use bevy_webview_wry::prelude::AllDialogPlugins;
@@ -59,9 +59,12 @@ fn main() {
                     filter: LogPlugin::default().filter,
                 })
                 .set(WindowPlugin {
-                    // Windows won't start without PrimaryWindow for some reason.
-                    #[cfg(not(target_os = "windows"))]
-                    primary_window: None,
+                    primary_window: Some(Window {
+                        resolution: WindowResolution::new(0., 0.),
+                        decorations: false,
+                        transparent: true,
+                        ..default()
+                    }),
                     exit_condition: ExitCondition::DontExit,
                     ..default()
                 })


### PR DESCRIPTION
In a multi-monitor setup, to correctly position all windows, it is necessary to obtain the scale factor of the current monitor at the time the application starts and adjust the window positions accordingly.

In previous implementations, this value was obtained from cursor position, but it sometimes could not be a detected correctly. To resolve this, now create a dummy primary window and obtain the current monitor using it.